### PR TITLE
Also merge "-lawgiver.pot"-files, adding ftw.lawgiver support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Also merge "-lawgiver.pot"-files, adding ftw.lawgiver support.
+  [jone]
 
 
 1.1.1 (2014-03-05)

--- a/ftw/recipe/translations/discovery.py
+++ b/ftw/recipe/translations/discovery.py
@@ -11,6 +11,7 @@ def discover_package(package_dir, package_name=None):
                      u'pot': None,
                      u'manual': None,
                      u'content': None,
+                     u'lawgiver': None,
                      u'languages': {}}
     items = defaultdict(Group)
 
@@ -33,6 +34,7 @@ def discover_package(package_dir, package_name=None):
         group[u'pot'] = unicode(match[u'relative_path'])
         group[u'manual'] = match[u'manual']
         group[u'content'] = match[u'content']
+        group[u'lawgiver'] = match[u'lawgiver']
 
         if group['locales'] is None:
             group['locales'] = match['locales']
@@ -81,6 +83,8 @@ def _find_pot_files(package_dir, package_name):
             continue
         if re.match('/.*-content\.pot$', filepath):
             continue
+        if re.match('/.*-lawgiver\.pot$', filepath):
+            continue
 
         manual = None
         manual_path = re.sub('\.pot$', '-manual.pot', filepath)
@@ -92,6 +96,11 @@ def _find_pot_files(package_dir, package_name):
         if os.path.exists(content_path):
             content = unicode(path(content_path).relpath(package_dir))
 
+        lawgiver = None
+        lawgiver_path = re.sub('\.pot$', '-lawgiver.pot', filepath)
+        if os.path.exists(lawgiver_path):
+            lawgiver = unicode(path(lawgiver_path).relpath(package_dir))
+
         yield {u'package': package_name,
                u'domain': unicode(filepath.basename().splitext()[0]),
                u'locales': os.path.dirname(path(filepath)
@@ -99,4 +108,5 @@ def _find_pot_files(package_dir, package_name):
                u'relative_path': path(filepath).relpath(package_dir),
                u'absolute_path': filepath,
                u'manual': manual,
-               u'content': content}
+               u'content': content,
+               u'lawgiver': lawgiver}

--- a/ftw/recipe/translations/i18ntools.py
+++ b/ftw/recipe/translations/i18ntools.py
@@ -24,13 +24,15 @@ def rebuild_package_potfiles(package_root, package_dir, primary_domain):
         if group['manual']:
             manual = os.path.join(package_dir, group['manual'])
 
-        content = ''
+        alternate_merge = ''
         if group['content']:
-            content = os.path.join(package_dir, group['content'])
+            alternate_merge = os.path.join(package_dir, group['content'])
+        if not alternate_merge and group['lawgiver']:
+            alternate_merge = os.path.join(package_dir, group['lawgiver'])
 
         potpath = os.path.join(package_dir, group['pot'])
         rebuild_pot(package_root, package_dir, primary_domain, potpath,
-                    manual, content)
+                    manual, alternate_merge)
 
 
 def rebuild_pot(package_root, package_dir, domain, potpath, manual, content):

--- a/ftw/recipe/translations/tests/test_discovery.py
+++ b/ftw/recipe/translations/tests/test_discovery.py
@@ -25,6 +25,7 @@ class TestDiscovery(TestCase):
               u'pot': u'foo/bar/locales/foo.bar.pot',
               u'manual': u'foo/bar/locales/foo.bar-manual.pot',
               u'content': None,
+              u'lawgiver': None,
               u'languages': {
                         u'de': u'foo/bar/locales/de/LC_MESSAGES/foo.bar.po',
                         u'en': u'foo/bar/locales/en/LC_MESSAGES/foo.bar.po'}}
@@ -47,6 +48,7 @@ class TestDiscovery(TestCase):
               u'pot': u'foo/bar/locales/foo.bar.pot',
               u'manual': None,
               u'content': None,
+              u'lawgiver': None,
               u'languages': {
                         u'de': u'foo/bar/locales/de/LC_MESSAGES/foo.bar.po',
                         u'en': u'foo/bar/locales/en/LC_MESSAGES/foo.bar.po'}}
@@ -70,6 +72,7 @@ class TestDiscovery(TestCase):
               u'pot': u'foo/locales/bar.pot',
               u'manual': None,
               u'content': None,
+              u'lawgiver': None,
               u'languages': {
                         u'de': u'foo/locales/de/LC_MESSAGES/bar.po'}},
 
@@ -79,6 +82,7 @@ class TestDiscovery(TestCase):
               u'pot': u'foo/locales/foo.pot',
               u'manual': None,
               u'content': None,
+              u'lawgiver': None,
               u'languages': {
                         u'de': u'foo/locales/de/LC_MESSAGES/foo.po',
                         u'en': u'foo/locales/en/LC_MESSAGES/foo.po'}}],
@@ -95,8 +99,9 @@ class TestDiscovery(TestCase):
               u'package': u'foo',
               u'locales': u'foo/locales',
               u'pot': None,
-              u'manual': None,
               u'content': None,
+              u'manual': None,
+              u'lawgiver': None,
               u'languages': {
                         u'en': u'foo/locales/en/LC_MESSAGES/foo.po'}}],
 
@@ -117,6 +122,7 @@ class TestDiscovery(TestCase):
               u'pot': u'bar/locales/foo.pot',
               u'manual': u'bar/locales/foo-manual.pot',
               u'content': None,
+              u'lawgiver': None,
               u'languages': {
                         u'en': u'bar/locales/en/LC_MESSAGES/foo.po'}},
 
@@ -126,6 +132,7 @@ class TestDiscovery(TestCase):
               u'pot': u'bar/locales/bar.pot',
               u'manual': None,
               u'content': None,
+              u'lawgiver': None,
               u'languages': {},
               }],
 
@@ -146,6 +153,7 @@ class TestDiscovery(TestCase):
               u'pot': u'bar/locales/foo.pot',
               u'manual': None,
               u'content': u'bar/locales/foo-content.pot',
+              u'lawgiver': None,
               u'languages': {
                         u'en': u'bar/locales/en/LC_MESSAGES/foo.po'}},
 
@@ -155,6 +163,38 @@ class TestDiscovery(TestCase):
               u'pot': u'bar/locales/bar.pot',
               u'manual': None,
               u'content': None,
+              u'lawgiver': None,
+              u'languages': {},
+              }],
+
+            discovery.discover(self.tempdir))
+
+    def test_lists_lawgiver_pot_files_in_respective_group(self):
+        fshelpers.create_structure(self.tempdir, {
+                u'foo/bar/locales/en/LC_MESSAGES/foo.po': u'',
+                u'foo/bar/locales/foo.pot': u'',
+                u'foo/bar/locales/bar.pot': u'',
+                u'foo/bar/locales/foo-lawgiver.pot': u'',
+                })
+
+        self.assertItemsEqual(
+            [{u'domain': u'foo',
+              u'package': u'foo',
+              u'locales': u'bar/locales',
+              u'pot': u'bar/locales/foo.pot',
+              u'manual': None,
+              u'content': None,
+              u'lawgiver': u'bar/locales/foo-lawgiver.pot',
+              u'languages': {
+                        u'en': u'bar/locales/en/LC_MESSAGES/foo.po'}},
+
+             {u'domain': u'bar',
+              u'package': u'foo',
+              u'locales': u'bar/locales',
+              u'pot': u'bar/locales/bar.pot',
+              u'manual': None,
+              u'content': None,
+              u'lawgiver': None,
               u'languages': {},
               }],
 

--- a/ftw/recipe/translations/tests/test_i18nbuild_command.py
+++ b/ftw/recipe/translations/tests/test_i18nbuild_command.py
@@ -63,6 +63,21 @@ class TestI18nbuildCommand(TestCase):
         self.assertEquals({'Foo': '',
                            'Login': ''}, pohelpers.messages(*pofile))
 
+    def test_merges_lawgiver_pot_files(self):
+        fshelpers.create_structure(self.tempdir, {
+                'foo/foo/__init__.py': '_("Foo")',
+                'foo/foo/locales/foo.pot': fshelpers.asset('empty.pot'),
+                'foo/foo/locales/foo-lawgiver.pot': fshelpers.asset(
+                    'foo.pot'),
+                'foo/foo/locales/de/LC_MESSAGES/foo.po': fshelpers.asset(
+                    'empty.po'),
+                })
+
+        build_translations(self.tempdir, self.tempdir, 'foo', output=None)
+        pofile = (self.tempdir, 'foo/foo/locales/de/LC_MESSAGES/foo.po')
+        self.assertEquals({'Foo': '',
+                           'Login': ''}, pohelpers.messages(*pofile))
+
     def test_syncs_po_files_of_existing_languages(self):
         fshelpers.create_structure(self.tempdir, {
                 'foo/foo/__init__.py': '_("Foo")',

--- a/ftw/recipe/translations/tests/test_i18ntools.py
+++ b/ftw/recipe/translations/tests/test_i18ntools.py
@@ -74,6 +74,19 @@ class TestRebuildPotfiles(TestCase):
         self.assertEquals({'Foo': '',
                            'Login': ''}, pohelpers.messages(*pofile))
 
+    def test_merges_lawgiver_pot_files(self):
+        fshelpers.create_structure(self.tempdir, {
+                'foo/foo/__init__.py': '_("Foo")',
+                'foo/foo/locales/foo.pot': fshelpers.asset('empty.pot'),
+                'foo/foo/locales/foo-lawgiver.pot': fshelpers.asset(
+                    'foo.pot'),
+                })
+
+        rebuild_package_potfiles(self.tempdir, self.tempdir, 'foo')
+        pofile = (self.tempdir, 'foo/foo/locales/foo.pot')
+        self.assertEquals({'Foo': '',
+                           'Login': ''}, pohelpers.messages(*pofile))
+
     def test_path_comments_are_relative_in_potfile(self):
         fshelpers.create_structure(self.tempdir, {
                 'foo/foo/__init__.py': '_("Foo")',


### PR DESCRIPTION
:construction: 

`ftw.lawgiver` will generate `ftw.lawgiver-lawgiver.pot` files for merging into the regulare pot file.
This pull-requests adds support for merging those.

It is not possible to use `-content.pot` and `-lawgiver.pot` at the same time because `i18ndude` only supports for two merge files (and `-manual.pot` is always first), but that should not be a problem since those are usually on different domains.

@deiferni can you take a look?
## 

Update:
The concept is not working how I expected it: the problem is once again that `plone` pot files are not built and therefore the `plone-lawgiver.pot` which is generated by `ftw.lawgiver` is never merged..
