### PR TITLE
Retain Plone KGS compatibility by pinning oauth2client and six dependencies

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Retain Plone KGS compatibility by pinning oauth2client and six dependencies.
+  [jone]
 
 
 1.2.0 (2014-06-05)

--- a/setup.py
+++ b/setup.py
@@ -42,15 +42,17 @@ setup(name='ftw.recipe.translations',
         'gspread',
         'i18ndude',
         'keyring',
-        'oauth2client',
         'path.py',
         'setuptools',
         'zc.buildout',
         'zc.recipe.egg',
 
-        # six is required by oauth2client, requiring >=1.4.1, but
-        # the Plone KGS pins it to a very old version.
-        'six>=1.4.1',
+        # For Plone KGS compatibility, we require an older six
+        # version (1.2.0).
+        'six <= 1.2.0',
+        # We also have to pin down oauth2client to the 
+        # version compatible with our old six version.
+        'oauth2client <= 1.3',
         ],
 
       tests_require=tests_require,

--- a/test.cfg
+++ b/test.cfg
@@ -10,9 +10,3 @@ package-name = ftw.recipe.translations
 
 [dependencychecker]
 eggs = z3c.dependencychecker
-
-
-[versions]
-# six is required by oauth2client, requiring >=1.4.1, but
-# the Plone KGS pins it to a very old version.
-six =


### PR DESCRIPTION
The recipe can no longer be installed in the same buildout configuration as a Plone since because the compatible version of `six` is conflicting: Plone requires an older version as our dependency `oauth2client`.

Therefore we pin down `oauth2client` as well as `six` to a compatible version for both.

Error was:

```
The constraint, 1.2.0, is not consistent with the requirement, 'six>=1.6.1'.
While:
  Installing.
  Getting section i18n-build.
  Initializing section i18n-build.
  Installing recipe ftw.recipe.translations.
Error: Bad constraint 1.2.0 six>=1.6.1
```
