### PR TITLE
Remove too strict six version pinning.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,22 @@ For installation simply use the zc.buildout recipe ``ftw.recipe.translations:pac
     recipe = ftw.recipe.translations:package
     package-name = my.package
 
+**Problems with ``six``**:
+
+``ftw.recipe.translations`` requires the ``oauth2client`` package, which requires
+``six``.
+Since Plone 4.3 requires an older ``six`` version
+(``1.2.0``, but ``1.4.0`` would work too) we use an older,
+compatible ``oauth2client`` version.
+If you install ``ftw.recipe.translations`` with Plone 4.2 or older, there is no
+version pinning and you need to pin down ``six``.
+We propose to use ``six = 1.4.0``, which is also compatible with ``lovely.buildouthttp``:
+
+.. code:: ini
+
+    [versions]
+    six = 1.4.0
+
 **Options:**
 
 package-name

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove too strict six version pinning.
+  six is pinned in Plone 4.3 KGS and newer.
+  For older Plone versions it should be pinned down, e.g. to `1.4.0`.
+  [jone]
 
 
 1.2.1 (2014-12-14)

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,9 @@ setup(name='ftw.recipe.translations',
         'zc.buildout',
         'zc.recipe.egg',
 
-        # For Plone KGS compatibility, we require an older six
-        # version (1.2.0).
-        'six <= 1.2.0',
-        # We also have to pin down oauth2client to the 
-        # version compatible with our old six version.
+        # We require an older oauth2client version since
+        # we probably have an old six version because of
+        # Plone compatibility.
         'oauth2client <= 1.3',
         ],
 


### PR DESCRIPTION
six is pinned in Plone 4.3 KGS and newer.
For older Plone versions it should be pinned down, e.g. to `1.4.0`.

- `lovely.buildouthttp` [requires at least `six == 1.4.0`](https://github.com/kelp404/six/blob/master/CHANGES#L163-L165)
- `ftw.recipe.translations` requires a six version compatible with `oauth2client <= 1.3` (1.4.0 seems to be compatible)
- Plone 4.3 [pins `six = 1.4.0`](http://dist.plone.org/release/4.3-latest/versions.cfg)
- ftw.buildout [pins `six = 1.4.0` for Plone 4.2 and 4.1](https://github.com/4teamwork/ftw-buildouts/commit/fb1e8d53f4082ec2f4016c8a8ce503df26c5fe2d)

@lukasgraf I think this should fix the world.