### PR TITLE
Refactor masstranslate recipe dependencies.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,33 +43,6 @@ For installation simply use the zc.buildout recipe ``ftw.recipe.translations:pac
     recipe = ftw.recipe.translations:package
     package-name = my.package
 
-**Problems with ``six``**:
-
-``ftw.recipe.translations`` requires the ``oauth2client`` package, which requires
-``six``.
-
-*Targeting Plone >= 4.3.4:*
-
-Pin ``six`` to ``1.8.0`` as Plone 4.3.6 also does.
-
-*Targeting Plone 4.3 - 4.3.2:*
-
-Since Plone <= 4.3.2 requires an older ``six`` version
-(``1.2.0``, but ``1.4.0`` would work too) we have to use an older,
-compatible ``oauth2client`` version. For this purpose please install ``ftw.recipe.translations 1.2.3``, this forces
-you to install an older oauth2client version.
-
-*Targeting Plone < 4.3:*
-
-If you install ``ftw.recipe.translations`` with Plone 4.2 or older, there is no
-version pinning and you need to pin down ``six``.
-We propose to use ``six = 1.4.0``, which is also compatible with ``lovely.buildouthttp``:
-
-.. code:: ini
-
-    [versions]
-    six = 1.4.0
-
 **Options:**
 
 package-name

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Require oauth2client (and six) dependencies only when installing
+  the masstranslate recipe.
+  This reduces dependency problems with six.
+  [jone]
 
 
 1.2.4 (2015-11-17)

--- a/ftw/recipe/translations/masstranslate/recipe.py
+++ b/ftw/recipe/translations/masstranslate/recipe.py
@@ -28,7 +28,7 @@ class Recipe(Egg):
         self._add_script_argument('spreadsheet')
 
         super(Recipe, self).__init__(buildout, name, options)
-        self.default_eggs = 'ftw.recipe.translations'
+        self.default_eggs = 'ftw.recipe.translations [masstranslate]'
 
     def _extend_initialization(self, code):
         self.options['initialization'] = '\n'.join((

--- a/ftw/recipe/translations/testing.py
+++ b/ftw/recipe/translations/testing.py
@@ -5,7 +5,7 @@ import tempfile
 import zc.buildout.testing
 
 
-def resolve_dependencies(pkg_name, result=None):
+def resolve_dependencies(pkg_name, result=None, extras=()):
     if result is None:
         result = set()
 
@@ -13,13 +13,14 @@ def resolve_dependencies(pkg_name, result=None):
         return result
 
     result.add(pkg_name)
-    for pkg in get_distribution(pkg_name).requires():
+    for pkg in get_distribution(pkg_name).requires(extras):
         resolve_dependencies(pkg.project_name, result)
 
     return result
 
 
 class RecipeLayer(Layer):
+    extras = ()
 
     @property
     def globs(self):
@@ -30,7 +31,8 @@ class RecipeLayer(Layer):
 
     def testSetUp(self):
         zc.buildout.testing.buildoutSetUp(self)
-        for pkgname in resolve_dependencies('ftw.recipe.translations'):
+        for pkgname in resolve_dependencies('ftw.recipe.translations',
+                                            extras=self.extras):
             zc.buildout.testing.install_develop(pkgname, self)
 
     def testTearDown(self):
@@ -38,6 +40,13 @@ class RecipeLayer(Layer):
 
 
 RECIPE_FIXTURE = RecipeLayer()
+
+
+class MasstranslateRecipeLayer(RecipeLayer):
+    extras = ('masstranslate',)
+
+
+MASSTRANSLATE_RECIPE_FIXTURE = MasstranslateRecipeLayer()
 
 
 class TempDirectory(Layer):

--- a/ftw/recipe/translations/tests/test_masstranslate_recipe.py
+++ b/ftw/recipe/translations/tests/test_masstranslate_recipe.py
@@ -1,4 +1,4 @@
-from ftw.recipe.translations.testing import RECIPE_FIXTURE
+from ftw.recipe.translations.testing import MASSTRANSLATE_RECIPE_FIXTURE
 from unittest2 import TestCase
 import os
 
@@ -13,7 +13,7 @@ DEFAULT_BUILDOUT_CONFIG = '\n'.join((
 
 class TestRecipe(TestCase):
 
-    layer = RECIPE_FIXTURE
+    layer = MASSTRANSLATE_RECIPE_FIXTURE
 
     def setUp(self):
         self.__dict__.update(self.layer['buildout'])

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,21 @@ from setuptools import setup, find_packages
 
 version = '1.2.5.dev0'
 
+extras = {
+    'tests': [
+        'mocker',
+        'plone.testing',
+        'unittest2',
+    ],
 
-tests_require = [
-    'mocker',
-    'plone.testing',
-    'unittest2',
-]
+    'masstranslate': [
+        'gspread',
+        'keyring',
+        'oauth2client',
+    ]
+}
+
+extras['tests'] += extras['masstranslate']
 
 
 setup(name='ftw.recipe.translations',
@@ -39,22 +48,15 @@ setup(name='ftw.recipe.translations',
 
       install_requires=[
           'argparse',
-          'gspread',
           'i18ndude',
-          'keyring',
           'path.py',
           'setuptools',
           'zc.buildout',
           'zc.recipe.egg',
-
-        # oauth2client 1.4.12 is the first version with acceptable dependency
-          # declaration. So we take at least this one. NOTE: This may breake
-          # compatibility with Plone 4.3.2 and older.
-        'oauth2client <= 1.4.12',
       ],
 
-      tests_require=tests_require,
-      extras_require=dict(tests=tests_require),
+      tests_require=extras['tests'],
+      extras_require=extras,
 
       entry_points = {
           'zc.buildout': [
@@ -63,5 +65,4 @@ setup(name='ftw.recipe.translations',
           'console_scripts': [
               'masstranslate = ftw.recipe.translations.masstranslate.command:main',
               'i18n-build = ftw.recipe.translations.i18nbuild.command:main']
-      },
-)
+      })


### PR DESCRIPTION
By making the "oauth2client" dependency an extras, we are not always installing "six". This reduces versions conflicts of "six" between the "oauth2client" package and Plone.

The recipe does automatically include the masstranslate-extras when the recipe is installed.

Close #8